### PR TITLE
Fix "buyer is undefined" in Altar and Armory

### DIFF
--- a/app/cards/dark_ages/altar.js
+++ b/app/cards/dark_ages/altar.js
@@ -30,7 +30,7 @@ Altar = class Altar extends Card {
     }
 
     let eligible_cards = _.filter(game.cards, function(card) {
-      return card.count > 0 && card.top_card.purchasable && CardCostComparer.coin_less_than(buyer.game, card.top_card, 6)
+      return card.count > 0 && card.top_card.purchasable && CardCostComparer.coin_less_than(game, card.top_card, 6)
     })
 
     if (_.size(eligible_cards) > 0) {

--- a/app/cards/dark_ages/armory.js
+++ b/app/cards/dark_ages/armory.js
@@ -10,7 +10,7 @@ Armory = class Armory extends Card {
 
   play(game, player_cards) {
     let eligible_cards = _.filter(game.cards, function(card) {
-      return card.count > 0 && card.top_card.purchasable && CardCostComparer.coin_less_than(buyer.game, card.top_card, 5)
+      return card.count > 0 && card.top_card.purchasable && CardCostComparer.coin_less_than(game, card.top_card, 5)
     })
 
     if (_.size(eligible_cards) > 0) {


### PR DESCRIPTION
`buyer` is not defined in the `play` method resulting in the game crashing.
