### PR TITLE
Fix "ReferenceError: all_player_cards is not defined" in prosperity/forge.js

### DIFF
--- a/app/cards/prosperity/forge.js
+++ b/app/cards/prosperity/forge.js
@@ -30,7 +30,7 @@ Forge = class Forge extends Card {
 
   static trash_cards(game, player_cards, selected_cards) {
     let cost = _.reduce(selected_cards, function(total_cost, card) {
-      return total_cost + CostCalculator.calculate(game, card, all_player_cards)
+      return total_cost + CostCalculator.calculate(game, card, player_cards)
     }, 0)
 
     let card_trasher = new CardTrasher(game, player_cards, 'hand', _.map(selected_cards, 'name'))


### PR DESCRIPTION
I ran into

```
Exception in callback of async function: ReferenceError: all_player_cards is not defined
    at app/cards/prosperity/forge.js:33:64
```

while playing with friends.  I _think_ this should fix it.  However, do you have any recommendations for testing?  Is there a way to choose specific cards before starting a new game?
