### PR TITLE
Adapt the UI to smaller screen sizes

### DIFF
--- a/app/game/client/game.scss
+++ b/app/game/client/game.scss
@@ -48,11 +48,15 @@ body {
   opacity: 0.4;
 }
 
-.card-container div {
+.card-thumbnail,
+.card-details {
   float: right;
 }
 
 .card-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: right;
   height: $card_height;
 }
 
@@ -75,11 +79,25 @@ body {
   padding-bottom: $event_height + 5px;
 }
 
-.event-container > div, .landmark-container > div {
+.event-thumbnail,
+.event-details,
+.landmark-thumbnail,
+.landmark-details {
   float: right;
 }
 
-.event-details, .landmark-details {
+.landmark-name,
+.event-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: right;
+  height: $event_height;
+  line-height: 15px;
+  padding-top: 7px;
+}
+
+.landmark-details,
+.event-details {
   text-align: center;
   padding-left: 8px;
   padding-right: 8px;

--- a/app/game/client/game.scss
+++ b/app/game/client/game.scss
@@ -49,20 +49,24 @@ body {
 }
 
 .card-thumbnail,
-.card-details {
+.card-details,
+.event-thumbnail,
+.event-details,
+.landmark-thumbnail,
+.landmark-details {
   float: right;
 }
 
 .card-name {
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
   text-align: right;
   height: $card_height;
 }
 
 .card-name span {
-  display: inline-block;
-  margin-top: 10px;
+  line-height: $card_height;
   padding: 1px;
 }
 
@@ -79,21 +83,18 @@ body {
   padding-bottom: $event_height + 5px;
 }
 
-.event-thumbnail,
-.event-details,
-.landmark-thumbnail,
-.landmark-details {
-  float: right;
-}
-
 .landmark-name,
 .event-name {
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
   text-align: right;
   height: $event_height;
-  line-height: 15px;
-  padding-top: 7px;
+}
+
+.landmark-name span,
+.event-name span {
+  line-height: $event_height;
 }
 
 .landmark-details,

--- a/app/game/client/game.scss
+++ b/app/game/client/game.scss
@@ -26,20 +26,12 @@ body {
   color: green;
 }
 
-.container {
-  width: 1410px;
-}
-
-#kingdom-cards {
-  width: 300px;
-}
-
 #game-over {
-  width: 700px;
   margin-top: 20px;
 }
 
 .card-container {
+  clear: both;
   height: $card_height;
   padding-bottom: $card_height + 5px;
 }
@@ -104,22 +96,15 @@ body {
   color: lightblue;
 }
 
-#common-cards, #not-supply-cards {
-  width: 210px;
-}
-
 #game-log {
   height: 250px;
+  margin-bottom: 20px;
   overflow: auto;
-  width: 700px;
-}
-
-#action-response {
-  width: 700px;
 }
 
 #hand {
   padding-top: 5px;
+  margin-bottom: 100px;
 }
 
 #hand ul {
@@ -164,17 +149,12 @@ body {
   padding: 1px;
 }
 
-#game-area {
-  width: 650px;
-}
-
 #game-chat {
   height: 100px;
   overflow: auto;
 }
 
 #game-chat, #message {
-  width: 1170px;
   margin-left: auto;
   margin-right: auto;
 }

--- a/app/game/client/templates/card.html
+++ b/app/game/client/templates/card.html
@@ -1,11 +1,12 @@
 <template name="card">
   <div class="card-container {{#unless count}}empty-pile{{/unless}}">
-    <div>
+    <div class="card-thumbnail">
       <img src="{{static_image top_card.image}}" width="29" height="46" class="card" data-name="{{name}}" />
       <div class="card-tooltip">
         <img src="{{static_image top_card.image}}" width="220" height="341" />
       </div>
     </div>
+
     <div class="card-details">
       ${{top_card.coin_cost}}
       {{#each times top_card.potion_cost}}
@@ -17,6 +18,7 @@
       <br />
       <span class="remaining">({{count}})</span>
     </div>
+
     <div class="card-name">
       {{#each tokens}}
         <span class="{{color}} token">{{text}}</span>

--- a/app/game/client/templates/event.html
+++ b/app/game/client/templates/event.html
@@ -1,16 +1,21 @@
 <template name="event">
   <div class="event-container">
-    <div>
+    <div class="event-thumbnail">
       <img src="{{static_image image}}" width="46" height="29" class="card" data-name="{{name}}" />
       <div class="card-tooltip">
         <img src="{{static_image image}}" width="341" height="220" />
       </div>
     </div>
+
     <div class="event-details">
-      {{name}}&nbsp;&nbsp;${{coin_cost}}
+      ${{coin_cost}}
       {{#if debt_cost}}
         <span class="debt">${{debt_cost}}</span>
       {{/if}}
+    </div>
+
+    <div class="event-name">
+      {{name}}
     </div>
   </div>
 </template>

--- a/app/game/client/templates/event.html
+++ b/app/game/client/templates/event.html
@@ -15,7 +15,7 @@
     </div>
 
     <div class="event-name">
-      {{name}}
+      <span class="stack-name">{{name}}</span>
     </div>
   </div>
 </template>

--- a/app/game/client/templates/game.html
+++ b/app/game/client/templates/game.html
@@ -2,34 +2,37 @@
 
   <div class="row">
 
-    <!-- Kingdom Cards -->
-    <div class="col-xs-3" id="kingdom-cards">
-      {{#each game.kingdom_cards}}
-        {{> card}}
-      {{/each}}
-    </div>
+    <div class="col-xs-5" id="cards-area">
+      <div class="row">
 
-    <div class="col-xs-2" id="common-cards">
-      <!-- Common Cards -->
-      <div id="common-cards">
-        {{#each game.common_cards}}
-          {{> card}}
-        {{/each}}
-      </div>
+        <!-- Kingdom Cards -->
+        <div class="col-xs-6 col-lg-4" id="kingdom-cards">
+          {{#each game.kingdom_cards}}
+            {{> card}}
+          {{/each}}
+        </div>
 
-      <hr/>
+        <!-- Common Cards -->
+        <div class="col-xs-6 col-lg-4" id="common-cards">
+          {{#each game.common_cards}}
+            {{> card}}
+          {{/each}}
+        </div>
 
-      <!-- Not Supply Cards -->
-      <div id="not-supply-cards">
-        {{#each game.not_supply_cards}}
-          {{> card}}
-        {{/each}}
-        {{#each game.events}}
-          {{> event}}
-        {{/each}}
-      {{#each game.landmarks}}
-        {{> landmark}}
-      {{/each}}
+        <!-- Not Supply Cards -->
+        <div class="col-xs-6 col-lg-4" id="not-supply-cards">
+          <hr class="hidden-lg" />
+          {{#each game.not_supply_cards}}
+            {{> card}}
+          {{/each}}
+          {{#each game.events}}
+            {{> event}}
+          {{/each}}
+          {{#each game.landmarks}}
+            {{> landmark}}
+          {{/each}}
+        </div>
+
       </div>
     </div>
 

--- a/app/game/client/templates/game.html
+++ b/app/game/client/templates/game.html
@@ -6,14 +6,14 @@
       <div class="row">
 
         <!-- Kingdom Cards -->
-        <div class="col-xs-6 col-lg-4 col-lg-push-4" id="kingdom-cards">
+        <div class="col-xs-6 col-lg-5 col-lg-push-4" id="kingdom-cards">
           {{#each game.kingdom_cards}}
             {{> card}}
           {{/each}}
         </div>
 
         <!-- Common Cards -->
-        <div class="col-xs-6 col-lg-4 col-lg-push-4" id="common-cards">
+        <div class="col-xs-6 col-lg-3 col-lg-push-4" id="common-cards">
           {{#each game.common_cards}}
             {{> card}}
           {{/each}}

--- a/app/game/client/templates/game.html
+++ b/app/game/client/templates/game.html
@@ -6,21 +6,21 @@
       <div class="row">
 
         <!-- Kingdom Cards -->
-        <div class="col-xs-6 col-lg-4" id="kingdom-cards">
+        <div class="col-xs-6 col-lg-4 col-lg-push-4" id="kingdom-cards">
           {{#each game.kingdom_cards}}
             {{> card}}
           {{/each}}
         </div>
 
         <!-- Common Cards -->
-        <div class="col-xs-6 col-lg-4" id="common-cards">
+        <div class="col-xs-6 col-lg-4 col-lg-push-4" id="common-cards">
           {{#each game.common_cards}}
             {{> card}}
           {{/each}}
         </div>
 
         <!-- Not Supply Cards -->
-        <div class="col-xs-6 col-lg-4" id="not-supply-cards">
+        <div class="col-xs-6 col-lg-4 col-lg-pull-8" id="not-supply-cards">
           <hr class="hidden-lg" />
           {{#each game.not_supply_cards}}
             {{> card}}

--- a/app/game/client/templates/game.html
+++ b/app/game/client/templates/game.html
@@ -2,34 +2,38 @@
 
   <div class="row">
 
-    <!-- Not Supply Cards -->
-    <div class="col-md-2" id="not-supply-cards">
-      {{#each game.not_supply_cards}}
-        {{> card}}
-      {{/each}}
-      {{#each game.events}}
-        {{> event}}
-      {{/each}}
-      {{#each game.landmarks}}
-        {{> landmark}}
-      {{/each}}
-    </div>
-
     <!-- Kingdom Cards -->
-    <div class="col-md-3" id="kingdom-cards">
+    <div class="col-xs-3" id="kingdom-cards">
       {{#each game.kingdom_cards}}
         {{> card}}
       {{/each}}
     </div>
 
-    <!-- Common Cards -->
-    <div class="col-md-1" id="common-cards">
-      {{#each game.common_cards}}
-        {{> card}}
+    <div class="col-xs-2" id="common-cards">
+      <!-- Common Cards -->
+      <div id="common-cards">
+        {{#each game.common_cards}}
+          {{> card}}
+        {{/each}}
+      </div>
+
+      <hr/>
+
+      <!-- Not Supply Cards -->
+      <div id="not-supply-cards">
+        {{#each game.not_supply_cards}}
+          {{> card}}
+        {{/each}}
+        {{#each game.events}}
+          {{> event}}
+        {{/each}}
+      {{#each game.landmarks}}
+        {{> landmark}}
       {{/each}}
+      </div>
     </div>
 
-    <div class="col-md-5" id="game-area">
+    <div class="col-xs-7" id="game-area">
       <div id="game-log">
         {{#each game.log}}
           {{> log}}
@@ -64,6 +68,7 @@
             {{/unless}}
           {{/unless}}
         </div>
+        <!-- required for floating divs in #action-area -->
         <br class="clear" />
         <div id="action-response">
           {{#if turn_event}}
@@ -78,16 +83,17 @@
           {{#each player_cards.hand}}
             {{> hand_card}}
           {{/each}}
+          <!-- give #hand a height corresponding to stacks of cards -->
+          <br class="clear" />
         </div>
       {{/if}}
+      <pre id="game-chat"></pre>
+      <form id="chat" action="">
+        <input id="message" class="form-control" autocomplete="off">
+      </form>
     </div>
   </div>
 
-  <br class="clear" />
-  <pre id="game-chat"></pre>
-  <form id="chat" action="">
-    <input id="message" class="form-control" autocomplete="off">
-  </form>
   {{#if currentUser.admin}}
     <br />
     <button id="destroy-game" class="btn btn-danger btn-xs">Destroy Game!!</button>

--- a/app/game/client/templates/game.html
+++ b/app/game/client/templates/game.html
@@ -94,11 +94,6 @@
     </div>
   </div>
 
-  {{#if currentUser.admin}}
-    <br />
-    <button id="destroy-game" class="btn btn-danger btn-xs">Destroy Game!!</button>
-  {{/if}}
-
   <div id='info-modal' class="modal fade" role="dialog">
     <div class="modal-dialog modal-lg">
       <div class="modal-content">
@@ -108,6 +103,13 @@
         </div>
         <div class="modal-body" id="extra-info">
           {{> game_info game=game player_cards=player_cards public_info=public_info}}
+
+          {{#if currentUser.admin}}
+            <button id="destroy-game" class="btn btn-danger btn-xs">
+              Destroy Game
+            </button>
+          {{/if}}
+
         </div>
       </div>
     </div>

--- a/app/game/client/templates/landmark.html
+++ b/app/game/client/templates/landmark.html
@@ -13,7 +13,7 @@
       {{#if victory_tokens}}
         <span class="token">{{victory_tokens}}x&nabla;</span>
       {{/if}}
-      {{name}}
+      <span class="stack-name">{{name}}</span>
     </div>
   </div>
 </template>

--- a/app/game/client/templates/landmark.html
+++ b/app/game/client/templates/landmark.html
@@ -1,12 +1,15 @@
 <template name="landmark">
   <div class="landmark-container">
-    <div>
+    <div class="landmark-thumbnail">
       <img src="http://images.mudbugmedia.com/dominion/images/cards/{{image}}.jpg" width="46" height="29" class="card" data-name="{{name}}" />
       <div class="card-tooltip">
         <img src="http://images.mudbugmedia.com/dominion/images/cards/{{image}}.jpg" width="341" height="220" />
       </div>
     </div>
-    <div class="landmark-details">
+
+    <div class="landmark-details"></div>
+
+    <div class="landmark-name">
       {{#if victory_tokens}}
         <span class="token">{{victory_tokens}}x&nabla;</span>
       {{/if}}

--- a/app/layout/client/layout.html
+++ b/app/layout/client/layout.html
@@ -4,7 +4,7 @@
 </head>
 <template name="layout">
   <nav class="navbar navbar-inverse navbar-fixed-top">
-    <div class="container">
+    <div class="container-fluid">
       <div class="navbar-header">
         <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
           <span class="icon-bar"></span>
@@ -29,7 +29,7 @@
     </div>
   </nav>
 
-  <div class="container">
+  <div class="container-fluid">
     <div class="starter-template">
       {{> yield}}
     </div>

--- a/app/layout/client/layout.scss
+++ b/app/layout/client/layout.scss
@@ -2,10 +2,6 @@ body {
     padding-top: 65px;
 }
 
-.navbar .container {
-  width: 1170px;
-}
-
 .clear {
   clear: both;
 }

--- a/app/lobby/client/lobby.scss
+++ b/app/lobby/client/lobby.scss
@@ -21,7 +21,6 @@ $player_margin: 25px;
 }
 
 #lobby-container {
-  width: 1170px;
   margin-left: auto;
   margin-right: auto;
 }


### PR DESCRIPTION
In this PR I tried to make the UI work better on smaller screens.

Using Bootstrap's fluid container helps make the most of the available screen estate.  I reduced the total number of columns in the UI by moving the non-supply cards under the common ones.  I also use `col-xs-*` grid classes to keep the current layout on smaller screens (phones and tablets).  The previously used `col-md-*` classes would cause the grid cells to stack vertically below 992px of width, i.e. on all phones and tablets.

Here's what the game looks like now on handhelds:

**iPad (1024x768):**

![dominion-game-yjtannsry7uppdt6s ipad](https://cloud.githubusercontent.com/assets/265818/17278285/e04e766c-5759-11e6-8a70-9c5ca2b8ef17.png)

**iPhone 5 (568x320):**

![dominion-game-yjtannsry7uppdt6s iphone 5](https://cloud.githubusercontent.com/assets/265818/17278286/e04ed526-5759-11e6-9882-99faed6d7266.png)
