### PR TITLE
Fixing Black Market

### DIFF
--- a/app/lobby/server/game_creator.js
+++ b/app/lobby/server/game_creator.js
@@ -603,7 +603,7 @@ GameCreator = class GameCreator {
       cards = cards.concat(this.black_market_deck)
     }
     return _.some(cards, function(card) {
-      return _.includes(_.words(card.top_card.types), 'fate') && card.name != 'Druid'
+      return _.includes(_.words(card.top_card ? card.top_card.types : card.types), 'fate') && card.name != 'Druid'
     })
   }
 
@@ -612,7 +612,7 @@ GameCreator = class GameCreator {
       cards = cards.concat(this.black_market_deck)
     }
     return _.some(cards, function(card) {
-      return _.includes(_.words(card.top_card.types), 'doom')
+      return _.includes(_.words(card.top_card ? card.top_card.types : card.types), 'doom')
     })
   }
 


### PR DESCRIPTION
Since `Nocturne` implementation Black Market wasn't really working - it wasn't possible to accept a game proposal if BM was in the selected kingdom because of a error:
<img width="1266" alt="screen shot 2018-10-03 at 02 12 31" src="https://user-images.githubusercontent.com/347657/46383741-417d2900-c6b2-11e8-8a75-289a987772b4.png">

This patch fixes that.