### PR TITLE
Fix Secret Passage

### DIFF
--- a/app/cards/intrigue/secret_passage.js
+++ b/app/cards/intrigue/secret_passage.js
@@ -47,9 +47,9 @@ SecretPassage = class SecretPassage extends Card {
       username: player_cards.username,
       type: 'overpay',
       player_cards: true,
-      instructions: `Choose where in your deck to put ${CardView.render(card_to_place_in_deck)} (0 is top of deck):`,
-      minimum: 0,
-      maximum: _.size(player_cards.deck)
+      instructions: `Choose where in your deck to put ${CardView.render(card_to_place_in_deck)} (1 is top of deck):`,
+      minimum: 1,
+      maximum: _.size(player_cards.deck) + 1
     })
     let turn_event_processor = new TurnEventProcessor(game, player_cards, turn_event_id, card_to_place_in_deck)
     turn_event_processor.process(SecretPassage.insert_in_deck)
@@ -62,7 +62,7 @@ SecretPassage = class SecretPassage extends Card {
     player_cards.hand.splice(hand_card_index, 1)[0]
 
     location = Number(location)
-    player_cards.deck.splice(location, 0, selected_card)
+    player_cards.deck.splice(location - 1, 0, selected_card)
     game.log.push(`&nbsp;&nbsp;<strong>${player_cards.username}</strong> inserts ${CardView.render(selected_card)} as card #${location}`)
   }
 

--- a/app/cards/intrigue/secret_passage.js
+++ b/app/cards/intrigue/secret_passage.js
@@ -47,8 +47,8 @@ SecretPassage = class SecretPassage extends Card {
       username: player_cards.username,
       type: 'overpay',
       player_cards: true,
-      instructions: `Choose where in your deck to put ${CardView.render(card_to_place_in_deck)} (1 is top of deck):`,
-      minimum: 1,
+      instructions: `Choose where in your deck to put ${CardView.render(card_to_place_in_deck)} (0 is top of deck):`,
+      minimum: 0,
       maximum: _.size(player_cards.deck)
     })
     let turn_event_processor = new TurnEventProcessor(game, player_cards, turn_event_id, card_to_place_in_deck)
@@ -62,7 +62,7 @@ SecretPassage = class SecretPassage extends Card {
     player_cards.hand.splice(hand_card_index, 1)[0]
 
     location = Number(location)
-    player_cards.deck.splice(location-1, 0, selected_card)
+    player_cards.deck.splice(location, 0, selected_card)
     game.log.push(`&nbsp;&nbsp;<strong>${player_cards.username}</strong> inserts ${CardView.render(selected_card)} as card #${location}`)
   }
 

--- a/app/game/client/templates/overpay.html
+++ b/app/game/client/templates/overpay.html
@@ -1,7 +1,7 @@
 <template name="overpay">
   <strong>{{{instructions}}} (Between {{minimum}} &amp; {{maximum}})</strong>
   <form id="turn-event">
-    <input id="overpay-input" type="number" name="overpay" />
+    <input id="overpay-input" type="number" name="overpay" min="{{minimum}}" max="{{maximum}}"/>
     <button type="submit" id="turn-event-button" class="btn btn-primary btn-xs">Submit</button>
   </form>
 </template>

--- a/app/game/client/templates/overpay.html
+++ b/app/game/client/templates/overpay.html
@@ -1,7 +1,7 @@
 <template name="overpay">
   <strong>{{{instructions}}} (Between {{minimum}} &amp; {{maximum}})</strong>
   <form id="turn-event">
-    <input id="overpay-input" type="number" name="overpay" min="{{minimum}}" max="{{maximum}}" />
+    <input id="overpay-input" type="number" name="overpay" />
     <button type="submit" id="turn-event-button" class="btn btn-primary btn-xs">Submit</button>
   </form>
 </template>

--- a/app/game/server/services/deck_shuffler.js
+++ b/app/game/server/services/deck_shuffler.js
@@ -25,7 +25,7 @@ DeckShuffler = class DeckShuffler {
           player_cards: true,
           instructions: 'Choose where in your deck to put Stash (1 is top of deck):',
           minimum: 1,
-          maximum: _.size(player_cards.deck)
+          maximum: _.size(player_cards.deck) + 1
         })
         let turn_event_processor = new TurnEventProcessor(game, player_cards, turn_event_id, stash)
         turn_event_processor.process(DeckShuffler.insert_stash)


### PR DESCRIPTION
When deck is empty after drawing +2 cards from secret passage, its not possible to put a card back into it (or cancel, or do anything - the game needs to be restarted):
<img width="718" alt="screen shot 2018-10-03 at 02 34 41" src="https://user-images.githubusercontent.com/347657/46384293-68892a00-c6b5-11e8-847f-146e83d47cfd.png">

This patch fixes that, but I'm not sure if it's the smartest way to do so, pls review carefully :).