### PR TITLE
Renaissance - Artifacts

### DIFF
--- a/app/cards/lib/card_list.js
+++ b/app/cards/lib/card_list.js
@@ -254,6 +254,7 @@ CardList = class CardList {
       'Seer',
       'Priest',
       'ActingTroupe',
+      'Treasurer',
       'Recruiter',
       'Sculptor',
       'SilkMerchant',

--- a/app/cards/lib/card_list.js
+++ b/app/cards/lib/card_list.js
@@ -258,7 +258,8 @@ CardList = class CardList {
       'Sculptor',
       'SilkMerchant',
       'Ducat',
-      'Villain'
+      'Villain',
+      'Swashbuckler'
     ]
   }
 

--- a/app/cards/lib/card_list.js
+++ b/app/cards/lib/card_list.js
@@ -248,6 +248,7 @@ CardList = class CardList {
   static renaissance() {
     return [
       'MountainVillage',
+      'FlagBearer',
       'Scholar',
       'Experiment',
       'Seer',

--- a/app/cards/lib/card_list.js
+++ b/app/cards/lib/card_list.js
@@ -254,18 +254,13 @@ CardList = class CardList {
       'Seer',
       'Priest',
       'ActingTroupe',
-      // 'Treasurer',
+      'Treasurer',
       'Border Guard',
-      // 'Recruiter',
-      // 'OldWitch',
-      'Lackeys',
-      // 'Inventor',
-      // 'Sculptor',
-      // 'SilkMerchant',
-      // 'Ducat',
-      // 'Villain',
-      // 'Swashbuckler',
-      'Spices'
+      'Recruiter',
+      'SilkMerchant',
+      'Ducat',
+      'Villain',
+      'Swashbuckler'
     ]
   }
 

--- a/app/cards/lib/card_list.js
+++ b/app/cards/lib/card_list.js
@@ -254,13 +254,18 @@ CardList = class CardList {
       'Seer',
       'Priest',
       'ActingTroupe',
-      'Treasurer',
-      'Recruiter',
-      'Sculptor',
-      'SilkMerchant',
-      'Ducat',
-      'Villain',
-      'Swashbuckler'
+      // 'Treasurer',
+      'Border Guard',
+      // 'Recruiter',
+      // 'OldWitch',
+      'Lackeys',
+      // 'Inventor',
+      // 'Sculptor',
+      // 'SilkMerchant',
+      // 'Ducat',
+      // 'Villain',
+      // 'Swashbuckler',
+      'Spices'
     ]
   }
 

--- a/app/cards/renaissance/artifacts/flag.js
+++ b/app/cards/renaissance/artifacts/flag.js
@@ -1,0 +1,7 @@
+Flag = class Flag extends State {
+
+    end_turn_event(game, player_cards) {
+        let card_drawer = new CardDrawer(game, player_cards)
+        card_drawer.draw(1)
+    }
+}

--- a/app/cards/renaissance/artifacts/horn.js
+++ b/app/cards/renaissance/artifacts/horn.js
@@ -1,0 +1,6 @@
+Horn = class Horn extends State {
+
+    start_turn_event(game, player_cards) {
+
+    }
+}

--- a/app/cards/renaissance/artifacts/horn.js
+++ b/app/cards/renaissance/artifacts/horn.js
@@ -1,6 +1,2 @@
 Horn = class Horn extends State {
-
-    start_turn_event(game, player_cards) {
-
-    }
 }

--- a/app/cards/renaissance/artifacts/key.js
+++ b/app/cards/renaissance/artifacts/key.js
@@ -1,0 +1,7 @@
+Key = class Key extends State {
+
+    start_turn_event(game, player_cards) {
+        let gained_coins = CoinGainer.gain(game, player_cards, 1)
+        game.log.push(`&nbsp;&nbsp;<strong>${player_cards.username}</strong> gets +$${gained_coins} from ${CardView.render(this, true)}`)
+    }
+}

--- a/app/cards/renaissance/artifacts/lantern.js
+++ b/app/cards/renaissance/artifacts/lantern.js
@@ -1,6 +1,2 @@
 Lantern = class Lantern extends State {
-
-    start_turn_event(game, player_cards) {
-
-    }
 }

--- a/app/cards/renaissance/artifacts/lantern.js
+++ b/app/cards/renaissance/artifacts/lantern.js
@@ -1,0 +1,6 @@
+Lantern = class Lantern extends State {
+
+    start_turn_event(game, player_cards) {
+
+    }
+}

--- a/app/cards/renaissance/artifacts/treasure_chest.js
+++ b/app/cards/renaissance/artifacts/treasure_chest.js
@@ -1,0 +1,7 @@
+TreasureChest = class TreasureChest extends State {
+
+    start_buy_event(game, player_cards) {
+        let card_gainer = new CardGainer(game, player_cards, 'discard', 'Gold')
+        card_gainer.gain_game_card()
+    }
+}

--- a/app/cards/renaissance/border_guard.js
+++ b/app/cards/renaissance/border_guard.js
@@ -10,7 +10,11 @@ BorderGuard = class BorderGuard extends Card {
 
     play(game, player_cards) {
         game.turn.actions += 1
-        let cards_to_reveal = 2
+        let lantern_index = _.findIndex(player_cards.artifacts, function (artifact) {
+            return artifact.name === 'Lantern'
+        })
+
+        let cards_to_reveal = lantern_index > -1 ? 3 : 2;
 
         if (_.size(player_cards.deck) === 0 && _.size(player_cards.discard) === 0) {
             game.log.push(`&nbsp;&nbsp;<strong>${player_cards.username}</strong> has no cards in deck`)
@@ -46,16 +50,13 @@ BorderGuard = class BorderGuard extends Card {
     }
 
     static put_in_hand(game, player_cards, selected_cards, are_all_actions) {
-        console.log({ are_all_actions })
         let selected_card = selected_cards[0]
         let selected_card_index = _.findIndex(player_cards.revealed, function(card) {
             return card.name === selected_card.name
         })
 
-        console.log(selected_card_index);
         player_cards.revealed.splice(selected_card_index, 1)
 
-        // console.log({discarded_card})
         player_cards.hand.push(selected_card)
         game.log.push(`&nbsp;&nbsp;<strong>${player_cards.username}</strong> puts ${CardView.render(selected_card)} in their hand`)
 

--- a/app/cards/renaissance/border_guard.js
+++ b/app/cards/renaissance/border_guard.js
@@ -1,0 +1,118 @@
+BorderGuard = class BorderGuard extends Card {
+
+    types() {
+        return ['action']
+    }
+
+    coin_cost() {
+        return 1
+    }
+
+    play(game, player_cards) {
+        game.turn.actions += 1
+        let cards_to_reveal = 2
+
+        if (_.size(player_cards.deck) === 0 && _.size(player_cards.discard) === 0) {
+            game.log.push(`&nbsp;&nbsp;<strong>${player_cards.username}</strong> has no cards in deck`)
+        } else {
+            player_cards.revealed = _.take(player_cards.deck, cards_to_reveal)
+            player_cards.deck = _.drop(player_cards.deck, cards_to_reveal)
+
+            let revealed_card_count = _.size(player_cards.revealed)
+            if (revealed_card_count < cards_to_reveal && _.size(player_cards.discard) > 0) {
+                DeckShuffler.shuffle(game, player_cards)
+                player_cards.revealed = player_cards.revealed.concat(_.take(player_cards.deck, cards_to_reveal - revealed_card_count))
+                player_cards.deck = _.drop(player_cards.deck, cards_to_reveal - revealed_card_count)
+            }
+
+            let are_all_actions = (_.size(player_cards.revealed) === cards_to_reveal) && _.every(player_cards.revealed, function (revealed_card) {
+                return _.includes(_.words(revealed_card.types), 'action')
+            });
+
+            let turn_event_id = TurnEventModel.insert({
+                game_id: game._id,
+                player_id: player_cards.player_id,
+                username: player_cards.username,
+                type: 'choose_cards',
+                player_cards: true,
+                instructions: 'Choose a card to put in hand:',
+                cards: player_cards.revealed,
+                minimum: 1,
+                maximum: 1
+            })
+            let turn_event_processor = new TurnEventProcessor(game, player_cards, turn_event_id, are_all_actions)
+            turn_event_processor.process(BorderGuard.put_in_hand)
+        }
+    }
+
+    static put_in_hand(game, player_cards, selected_cards, are_all_actions) {
+        console.log({ are_all_actions })
+        let selected_card = selected_cards[0]
+        let selected_card_index = _.findIndex(player_cards.revealed, function(card) {
+            return card.name === selected_card.name
+        })
+
+        console.log(selected_card_index);
+        player_cards.revealed.splice(selected_card_index, 1)
+
+        // console.log({discarded_card})
+        player_cards.hand.push(selected_card)
+        game.log.push(`&nbsp;&nbsp;<strong>${player_cards.username}</strong> puts ${CardView.render(selected_card)} in their hand`)
+
+        let card_discarder = new CardDiscarder(game, player_cards, 'revealed', _.map(player_cards.revealed, 'name'))
+        card_discarder.discard()
+
+        if (are_all_actions) {
+            let turn_event_id = TurnEventModel.insert({
+                game_id: game._id,
+                player_id: player_cards.player_id,
+                username: player_cards.username,
+                type: 'choose_options',
+                instructions: `Choose One:`,
+                minimum: 1,
+                maximum: 1,
+                options: [
+                    { text: 'Take the Horn', value: 'horn' },
+                    { text: 'Take the Lantern', value: 'lantern' }
+                ]
+            })
+
+            let turn_event_processor = new TurnEventProcessor(game, player_cards, turn_event_id)
+            turn_event_processor.process(BorderGuard.process_response)
+        }
+    }
+
+    static process_response(game, player_cards, response) {
+        response = response[0]
+        if (response === 'horn') {
+            BorderGuard.get_artifact(game, player_cards, new Horn(), 'Horn')
+        } else if (response === 'lantern') {
+            BorderGuard.get_artifact(game, player_cards, new Lantern(), 'Lantern')
+        }
+    }
+
+    static get_artifact(game, player_cards, artifact_instance, artifact_name) {
+        let artifact_index = _.findIndex(player_cards.artifacts, function (artifact) {
+            return artifact.name === artifact_name
+        })
+
+        if (artifact_index === -1) {
+            let ordered_player_cards = TurnOrderedPlayerCardsQuery.turn_ordered_player_cards(game, player_cards)
+            ordered_player_cards.shift()
+
+            _.each(ordered_player_cards, function (other_player_cards) {
+                let other_player_artifact_index = _.findIndex(other_player_cards.artifacts, function (artifact) {
+                    return artifact.name === artifact_name
+                })
+                if (other_player_artifact_index !== -1) {
+                    other_player_cards.artifacts.splice(other_player_artifact_index, 1)
+                }
+                PlayerCardsModel.update(game._id, other_player_cards)
+            })
+
+            let artifact = artifact_instance.to_h()
+            player_cards.artifacts.push(artifact)
+            game.log.push(`&nbsp;&nbsp;<strong>${player_cards.username}</strong> takes ${CardView.render(artifact, true)}`)
+        }
+    }
+}

--- a/app/cards/renaissance/flag_bearer.js
+++ b/app/cards/renaissance/flag_bearer.js
@@ -1,0 +1,62 @@
+FlagBearer = class FlagBearer extends Card {
+
+    types() {
+        return ['action']
+    }
+
+    coin_cost() {
+        return 4
+    }
+
+    artifact_name() {
+        return 'Flag'
+    }
+
+    get_artifact_instance() {
+        return new Flag()
+    }
+
+    play(game, player_cards) {
+        let gained_coins = CoinGainer.gain(game, player_cards, 2)
+        game.log.push(`&nbsp;&nbsp;<strong>${player_cards.username}</strong> gets +$${gained_coins}`)
+    }
+
+    get_artifact(game, player_cards) {
+        let self = this;
+
+        let artifact_index = _.findIndex(player_cards.artifacts, function (artifact) {
+            return artifact.name === self.artifact_name()
+        })
+
+        if (artifact_index === -1) {
+            let ordered_player_cards = TurnOrderedPlayerCardsQuery.turn_ordered_player_cards(game, player_cards)
+            ordered_player_cards.shift()
+
+            _.each(ordered_player_cards, function (other_player_cards) {
+                let other_player_artifact_index = _.findIndex(other_player_cards.artifacts, function (artifact) {
+                    return artifact.name === self.artifact_name()
+                })
+                if (other_player_artifact_index !== -1) {
+                    other_player_cards.artifacts.splice(other_player_artifact_index, 1)
+                }
+                PlayerCardsModel.update(game._id, other_player_cards)
+            })
+
+            let artifact = (this.get_artifact_instance()).to_h()
+            player_cards.artifacts.push(artifact)
+            game.log.push(`&nbsp;&nbsp;<strong>${player_cards.username}</strong> takes ${CardView.render(artifact, true)}`)
+        }
+    }
+
+    gain_or_trash_event(player) {
+        this.get_artifact(player.game, player.player_cards)
+    }
+
+    gain_event(buyer) {
+        this.gain_or_trash_event(buyer)
+    }
+
+    trash_event(trasher) {
+        this.gain_or_trash_event(trasher)
+    }
+}

--- a/app/cards/renaissance/swashbuckler.js
+++ b/app/cards/renaissance/swashbuckler.js
@@ -1,0 +1,63 @@
+Swashbuckler = class Swashbuckler extends Card {
+
+    types() {
+        return ['action']
+    }
+
+    coin_cost() {
+        return 5
+    }
+
+    artifact_name() {
+        return 'Treasure Chest'
+    }
+
+    get_artifact_instance() {
+        return new TreasureChest()
+    }
+
+    play(game, player_cards) {
+        let card_drawer = new CardDrawer(game, player_cards)
+        let drawn_count = card_drawer.draw(3)
+
+        if (_.size(player_cards.discard) > 0) {
+            player_cards.coin_tokens += 1
+            game.log.push(`&nbsp;&nbsp;<strong>${player_cards.username}</strong> takes a coin token`)
+
+            if (player_cards.coin_tokens > 3) {
+                this.get_artifact(game, player_cards)
+            }
+        } else {
+            game.log.push(`&nbsp;&nbsp;<strong>${player_cards.username}</strong>'s discard pile is empty`)
+        }
+    }
+
+    get_artifact(game, player_cards) {
+        let self = this;
+
+        let artifact_index = _.findIndex(player_cards.artifacts, function (artifact) {
+            return artifact.name === self.artifact_name()
+        })
+
+        if (artifact_index === -1) {
+            let ordered_player_cards = TurnOrderedPlayerCardsQuery.turn_ordered_player_cards(game, player_cards)
+            ordered_player_cards.shift()
+
+            _.each(ordered_player_cards, function (other_player_cards) {
+                let other_player_artifact_index = _.findIndex(other_player_cards.artifacts, function (artifact) {
+                    return artifact.name === self.artifact_name()
+                })
+                if (other_player_artifact_index !== -1) {
+                    other_player_cards.artifacts.splice(other_player_artifact_index, 1)
+                }
+                PlayerCardsModel.update(game._id, other_player_cards)
+            })
+
+            let artifact = (this.get_artifact_instance()).to_h()
+            player_cards.artifacts.push(artifact)
+            game.log.push(`&nbsp;&nbsp;<strong>${player_cards.username}</strong> takes ${CardView.render(artifact, true)}`)
+        }
+    }
+
+
+}

--- a/app/cards/renaissance/treasurer.js
+++ b/app/cards/renaissance/treasurer.js
@@ -1,0 +1,139 @@
+Treasurer = class Treasurer extends Card {
+
+    types() {
+        return ['action']
+    }
+
+    coin_cost() {
+        return 5
+    }
+
+    static artifact_name() {
+        return 'Key'
+    }
+
+    static get_artifact_instance() {
+        return new Key()
+    }
+
+    play(game, player_cards) {
+        let gained_coins = CoinGainer.gain(game, player_cards, 3)
+        game.log.push(`&nbsp;&nbsp;<strong>${player_cards.username}</strong> gets +$${gained_coins}`)
+
+        let turn_event_id = TurnEventModel.insert({
+            game_id: game._id,
+            player_id: player_cards.player_id,
+            username: player_cards.username,
+            type: 'choose_options',
+            instructions: `Choose One:`,
+            minimum: 1,
+            maximum: 1,
+            options: [
+                { text: 'Trash Treasures from hand', value: 'trash' },
+                { text: 'Gain Treasure from trash', value: 'gain' },
+                { text: 'take the Key', value: 'artifact' }
+            ]
+        })
+        let turn_event_processor = new TurnEventProcessor(game, player_cards, turn_event_id)
+        turn_event_processor.process(Treasurer.process_response)
+
+    }
+
+    static process_response(game, player_cards, response) {
+        response = response[0]
+        if (response === 'artifact') {
+            Treasurer.get_artifact(game, player_cards)
+        } else if (response === 'trash') {
+            Treasurer.trash_treasure(game, player_cards)
+        } else if (response === 'gain') {
+            Treasurer.gain_tresure_from_trash(game, player_cards)
+        }
+    }
+
+    static gain_tresure_from_trash(game, player_cards) {
+        let eligible_cards = _.filter(game.trash, function (card) {
+            return _.includes(_.words(card.types), 'treasure')
+        })
+
+        if (_.size(eligible_cards) > 1) {
+            let turn_event_id = TurnEventModel.insert({
+                game_id: game._id,
+                player_id: player_cards.player_id,
+                username: player_cards.username,
+                type: 'choose_cards',
+                instructions: 'Choose a tresure to gain:',
+                cards: eligible_cards,
+                minimum: 1,
+                maximum: 1
+            })
+            let turn_event_processor = new TurnEventProcessor(game, player_cards, turn_event_id)
+            turn_event_processor.process(Treasurer.gain_from_trash)
+        } else if (_.size(eligible_cards) === 1) {
+            Treasurer.gain_from_trash(game, player_cards, eligible_cards)
+        } else {
+            game.log.push(`&nbsp;&nbsp;but there are no available cards to gain`)
+        }
+    }
+
+    static gain_from_trash(game, player_cards, selected_cards) {
+        let card_gainer = new CardGainer(game, player_cards, 'hand', selected_cards[0].name)
+        card_gainer.gain_trash_card()
+    }
+
+    static trash_treasure(game, player_cards) {
+        let eligible_cards = _.filter(player_cards.hand, function (card) {
+            return _.includes(_.words(card.types), 'treasure')
+        })
+        if (_.size(eligible_cards) > 0) {
+            let turn_event_id = TurnEventModel.insert({
+                game_id: game._id,
+                player_id: player_cards.player_id,
+                username: player_cards.username,
+                type: 'choose_cards',
+                player_cards: true,
+                instructions: 'Choose a treasure to trash:',
+                cards: eligible_cards,
+                minimum: 1,
+                maximum: 1
+            })
+            let turn_event_processor = new TurnEventProcessor(game, player_cards, turn_event_id)
+            turn_event_processor.process(Treasurer.trash_card)
+        } else {
+            game.log.push(`&nbsp;&nbsp;but does not have any treasures in hand`)
+        }
+    }
+
+    static trash_card(game, player_cards, selected_cards) {
+        let selected_card = selected_cards[0]
+
+        let card_trasher = new CardTrasher(game, player_cards, 'hand', selected_card.name)
+        card_trasher.trash()
+    }
+
+    static get_artifact(game, player_cards) {
+        let artifact_index = _.findIndex(player_cards.artifacts, function (artifact) {
+            return artifact.name === Treasurer.artifact_name()
+        })
+
+        if (artifact_index === -1) {
+            let ordered_player_cards = TurnOrderedPlayerCardsQuery.turn_ordered_player_cards(game, player_cards)
+            ordered_player_cards.shift()
+
+            _.each(ordered_player_cards, function (other_player_cards) {
+                let other_player_artifact_index = _.findIndex(other_player_cards.artifacts, function (artifact) {
+                    return artifact.name === Treasurer.artifact_name()
+                })
+                if (other_player_artifact_index !== -1) {
+                    other_player_cards.artifacts.splice(other_player_artifact_index, 1)
+                }
+                PlayerCardsModel.update(game._id, other_player_cards)
+            })
+
+            let artifact = (Treasurer.get_artifact_instance()).to_h()
+            player_cards.artifacts.push(artifact)
+            game.log.push(`&nbsp;&nbsp;<strong>${player_cards.username}</strong> takes ${CardView.render(artifact, true)}`)
+        }
+    }
+
+
+}

--- a/app/cards/renaissance/treasurer.js
+++ b/app/cards/renaissance/treasurer.js
@@ -29,9 +29,9 @@ Treasurer = class Treasurer extends Card {
             minimum: 1,
             maximum: 1,
             options: [
-                { text: 'Trash Treasures from hand', value: 'trash' },
-                { text: 'Gain Treasure from trash', value: 'gain' },
-                { text: 'take the Key', value: 'artifact' }
+                { text: 'Trash a treasures from hand', value: 'trash' },
+                { text: 'Gain a treasure from trash', value: 'gain' },
+                { text: 'Take the Key', value: 'artifact' }
             ]
         })
         let turn_event_processor = new TurnEventProcessor(game, player_cards, turn_event_id)

--- a/app/game/client/game.js
+++ b/app/game/client/game.js
@@ -24,7 +24,7 @@ function registerStreams() {
 
 function createPopovers() {
   $('body').popover({
-    selector: '.card-container .card, .event-container .card, .hand-card, .prize-card, .trash-card, .black-market-card, .choose-card, .landmark-container .card, .boon-container .card, #game-log span.card, #instructions .card, #action-response span.boon, #action-response span.hex',
+    selector: '.card-container .card, .event-container .card, .hand-card, .prize-card, .trash-card, .black-market-card, .choose-card, .landmark-container .card, .boon-container .card, .artifact-container .card, #game-log span.card, #instructions .card, #action-response span.boon, #action-response span.hex',
     html: true,
     content: function() {
       return $(this).next('.card-tooltip').html()

--- a/app/game/client/game.scss
+++ b/app/game/client/game.scss
@@ -55,6 +55,8 @@ body {
 .landmark-thumbnail,
 .landmark-details,
 .boon-thumbnail,
+.artifact-thumbnail,
+.artifact-details,
 .boon-details {
   float: right;
 }
@@ -80,14 +82,18 @@ body {
   padding-top: 5px;
 }
 
-.event-container, .landmark-container, .boon-container {
+.event-container,
+.landmark-container,
+.boon-container,
+.artifact-container {
   height: $event_height;
   padding-bottom: $event_height + 5px;
 }
 
 .landmark-name,
 .event-name,
-.boon-name {
+.boon-name,
+.artifact-name {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -97,13 +103,15 @@ body {
 
 .landmark-name span,
 .event-name span,
-.boon-name span {
+.boon-name span,
+.artifact-name span {
   line-height: $event_height;
 }
 
 .landmark-details,
 .event-details,
-.boon-details {
+.boon-details,
+.artifact-details {
   text-align: center;
   padding-left: 8px;
   padding-right: 8px;

--- a/app/game/client/templates/artifact.html
+++ b/app/game/client/templates/artifact.html
@@ -1,0 +1,16 @@
+<template name="artifact">
+  <div class="artifact-container">
+    <div class="artifact-thumbnail">
+      <img src="{{static_image image}}" width="46" height="29" class="card" data-name="{{name}}" />
+      <div class="card-tooltip">
+        <img src="{{static_image image}}" width="341" height="220" />
+      </div>
+    </div>
+
+    <div class="artifact-details"></div>
+
+    <div class="artifact-name">
+      <span class="stack-name">{{name}}</span>
+    </div>
+  </div>
+</template>

--- a/app/game/client/templates/game.html
+++ b/app/game/client/templates/game.html
@@ -31,6 +31,9 @@
           {{#each game.druid_boons}}
             {{> druid_boon}}
           {{/each}}
+          {{#each game.artifacts}}
+            {{> artifact}}
+          {{/each}}
           {{#each game.not_supply_cards}}
             {{> card}}
           {{/each}}

--- a/app/game/client/templates/game_info.html
+++ b/app/game/client/templates/game_info.html
@@ -124,6 +124,13 @@
       {{/each}}
       <br />
     {{/if}}
+    {{#if artifacts}}
+      Artifacts:
+      {{#each artifacts}}
+        <span class="{{types}}">{{name}}</span>
+      {{/each}}
+      <br />
+    {{/if}}
     <br />
   {{/each}}
 </template>

--- a/app/game/server/services/discard_event_processor.js
+++ b/app/game/server/services/discard_event_processor.js
@@ -1,7 +1,7 @@
 DiscardEventProcessor = class DiscardEventProcessor {
 
   static event_cards() {
-    return ['Treasury', 'Herbalist', 'Alchemist', 'Hermit', 'Tunnel', 'Capital', 'Faithful Hound']
+    return ['Treasury', 'Herbalist', 'Alchemist', 'Hermit', 'Tunnel', 'Capital', 'Faithful Hound', 'Border Guard']
   }
 
   static traveller_cards() {
@@ -55,6 +55,8 @@ DiscardEventProcessor = class DiscardEventProcessor {
         if (_.isEmpty(this.discarder.game.turn.bought_cards)) {
           this.discard_events.push(this.card)
         }
+      } else if (this.discarder.source === 'in_play') {
+        this.discard_events.push(this.card)
       }
     }
 

--- a/app/game/server/services/end_turn_event_processor.js
+++ b/app/game/server/services/end_turn_event_processor.js
@@ -4,6 +4,10 @@ EndTurnEventProcessor = class EndTurnEventProcessor {
     return ['Baths']
   }
 
+  static artifacts_events() {
+    return ['Flag']
+  }
+
   constructor(game, player_cards) {
     this.game = game
     this.player_cards = player_cards
@@ -23,6 +27,10 @@ EndTurnEventProcessor = class EndTurnEventProcessor {
       }
     })
 
+    let artifacts_events = _.filter(this.player_cards.artifacts, function(artifact) {
+      return _.includes(EndTurnEventProcessor.artifacts_events(), artifact.name)
+    });
+
     let river_gift_events = _.map(this.game.turn.river_gifts, function(card) {
       card.end_turn_event_type = 'The Rivers Gift'
       return card
@@ -33,7 +41,7 @@ EndTurnEventProcessor = class EndTurnEventProcessor {
       return card
     })
 
-    this.end_turn_events = landmark_events.concat(river_gift_events).concat(faithful_hound_events)
+    this.end_turn_events = landmark_events.concat(river_gift_events).concat(faithful_hound_events).concat(artifacts_events)
   }
 
   process() {

--- a/app/game/server/services/gain_event_processor.js
+++ b/app/game/server/services/gain_event_processor.js
@@ -5,7 +5,7 @@ GainEventProcessor = class GainEventProcessor {
   }
 
   static event_cards() {
-    return ['Duchy', 'Cache', 'Embassy', 'Ill Gotten Gains', 'Inn', 'Mandarin', 'Border Village', 'Death Cart', 'Lost City', 'Emporium', 'Crumbling Castle', 'Haunted Castle', 'Sprawling Castle', 'Grand Castle', 'Rocks', 'Fortune', 'Temple', 'Villa', 'Blessed Village', 'Cemetery', 'Skulk', 'Cursed Village', 'Ducat', 'Experiment', 'Silk Merchant']
+    return ['Duchy', 'Cache', 'Embassy', 'Ill Gotten Gains', 'Inn', 'Mandarin', 'Border Village', 'Death Cart', 'Lost City', 'Emporium', 'Crumbling Castle', 'Haunted Castle', 'Sprawling Castle', 'Grand Castle', 'Rocks', 'Fortune', 'Temple', 'Villa', 'Blessed Village', 'Cemetery', 'Skulk', 'Cursed Village', 'Ducat', 'Experiment', 'Silk Merchant', 'Flag Bearer']
   }
 
   static in_play_event_cards() {

--- a/app/game/server/services/start_buy_event_processor.js
+++ b/app/game/server/services/start_buy_event_processor.js
@@ -4,6 +4,10 @@ StartBuyEventProcessor = class StartBuyEventProcessor {
     return ['Arena']
   }
 
+  static artifact_events() {
+    return ['Treasure Chest']
+  }
+
   static state_events() {
     return ['Deluded', 'Envious']
   }
@@ -33,7 +37,12 @@ StartBuyEventProcessor = class StartBuyEventProcessor {
     let state_events = _.filter(this.player_cards.states, function(card) {
       return _.includes(StartBuyEventProcessor.state_events(), card.name)
     })
-    this.start_buy_events = landmark_events.concat(state_events)
+
+    let artifact_events = _.filter(this.player_cards.artifacts, function(card) {
+      return _.includes(StartBuyEventProcessor.artifact_events(), card.name)
+    })
+
+    this.start_buy_events = landmark_events.concat(state_events).concat(artifact_events)
   }
 
   process() {

--- a/app/game/server/services/start_turn_event_processor.js
+++ b/app/game/server/services/start_turn_event_processor.js
@@ -8,6 +8,10 @@ StartTurnEventProcessor = class StartTurnEventProcessor {
     return ['Lost In The Woods']
   }
 
+  static artifact_events() {
+    return ['Key']
+  }
+
   constructor(game, player_cards) {
     this.game = game
     this.player_cards = player_cards
@@ -50,7 +54,12 @@ StartTurnEventProcessor = class StartTurnEventProcessor {
       return _.includes(StartTurnEventProcessor.state_events(), card.name)
     })
 
-    this.start_turn_events = horse_traders_events.concat(duration_events).concat(prince_events).concat(reserve_events).concat(summon_events).concat(state_events).concat(saved_boon_events)
+    let artifact_events = _.filter(this.player_cards.artifacts, function(card) {
+      card.start_event_type = 'Artifact'
+      return _.includes(StartTurnEventProcessor.artifact_events(), card.name)
+    })
+
+    this.start_turn_events = horse_traders_events.concat(duration_events).concat(prince_events).concat(reserve_events).concat(summon_events).concat(state_events).concat(saved_boon_events).concat(artifact_events)
   }
 
   process() {
@@ -116,7 +125,7 @@ StartTurnEventProcessor = class StartTurnEventProcessor {
       } else if (event.start_event_type === 'Reserve') {
         delete event.start_event_type
         selected_event.reserve(game, player_cards)
-      } else if (event.start_event_type === 'State') {
+      } else if (event.start_event_type === 'State' || event.start_event_type === 'Artifact') {
         delete event.start_event_type
         selected_event.start_turn_event(game, player_cards)
       }

--- a/app/game/server/services/trash_event_processor.js
+++ b/app/game/server/services/trash_event_processor.js
@@ -9,7 +9,7 @@ TrashEventProcessor = class BuyEventProcessor {
   }
 
   static event_cards() {
-    return ['Overgrown Estate', 'Squire', 'Feodum', 'Fortress', 'Sir Vander', 'Cultist', 'Hunting Grounds', 'Rats', 'Catacombs', 'Crumbling Castle', 'Rocks', 'Haunted Mirror', 'Silk Merchant']
+    return ['Overgrown Estate', 'Squire', 'Feodum', 'Fortress', 'Sir Vander', 'Cultist', 'Hunting Grounds', 'Rats', 'Catacombs', 'Crumbling Castle', 'Rocks', 'Haunted Mirror', 'Silk Merchant', 'Flag Bearer']
   }
 
   constructor(trasher, card) {

--- a/app/game/server/services/turn_ender.js
+++ b/app/game/server/services/turn_ender.js
@@ -211,6 +211,7 @@ TurnEnder = class TurnEnder {
       expeditions: 0,
       charms: 0,
       priests: 0,
+      horns: 0,
       experiments_gained: 0,
       previous_player: this.game.turn.player
     }

--- a/app/lobby/client/lobby.scss
+++ b/app/lobby/client/lobby.scss
@@ -9,6 +9,7 @@ $duration: orange;
 $night: grey;
 $shelter: salmon;
 $state: peachpuff;
+$artifact: firebrick;
 $ruins: burlywood;
 $reserve: #cdb332;
 $busy: grey;
@@ -118,6 +119,10 @@ hr {
 
 .landmark {
   background-color: $landmark;
+}
+
+.artifact {
+  background-color: $artifact;
 }
 
 .action.victory {

--- a/app/lobby/server/game_creator.js
+++ b/app/lobby/server/game_creator.js
@@ -47,6 +47,9 @@ GameCreator = class GameCreator {
     if (this.druid_boons) {
       game_attributes.druid_boons = this.druid_boons
     }
+    if (this.artifacts) {
+      game_attributes.artifacts = this.artifacts
+    }
     if (this.boons_deck) {
       game_attributes.boons_deck = this.boons_deck
       game_attributes.boons_discard = []
@@ -239,6 +242,23 @@ GameCreator = class GameCreator {
 
     if (this.game_has_card(kingdom_cards, 'Druid')) {
       this.select_druid_boons()
+    }
+
+    if (this.game_has_card(kingdom_cards, 'Border Guard')) {
+      this.add_artifact(Horn)
+      this.add_artifact(Lantern)
+    }
+
+    if (this.game_has_card(kingdom_cards, 'Flag Bearer')) {
+      this.add_artifact(Flag)
+    }
+
+    if (this.game_has_card(kingdom_cards, 'Treasurer')) {
+      this.add_artifact(Key)
+    }
+
+    if (this.game_has_card(kingdom_cards, 'Swashbuckler')) {
+      this.add_artifact(TreasureChest)
     }
 
     if (this.has_boons(kingdom_cards)) {
@@ -668,6 +688,11 @@ GameCreator = class GameCreator {
 
   select_druid_boons() {
     this.druid_boons = _.take(_.shuffle(this.boons()), 3)
+  }
+
+  add_artifact(artifact) {
+    this.artifacts = this.artifacts || []
+    this.artifacts.push((new artifact()).to_h())
   }
 
   build_boons_deck() {

--- a/app/lobby/server/game_creator.js
+++ b/app/lobby/server/game_creator.js
@@ -100,6 +100,7 @@ GameCreator = class GameCreator {
       expeditions: 0,
       charms: 0,
       priests: 0,
+      horns: 0,
       experiments_gained: 0
     }
   }

--- a/lib/controllers/game_controller.js
+++ b/lib/controllers/game_controller.js
@@ -127,6 +127,9 @@ GameController = LoggedInController.extend({
             if (_.size(player_cards.states) > 0) {
               public_info.states = player_cards.states
             }
+            if (_.size(player_cards.artifacts) > 0) {
+              public_info.artifacts = player_cards.artifacts
+            }
             if (player_cards.tokens.journey) {
               public_info.journey_token = player_cards.tokens.journey
             }

--- a/lib/server/models/player_cards_model.js
+++ b/lib/server/models/player_cards_model.js
@@ -21,6 +21,7 @@ PlayerCardsModel = class PlayerCardsModel extends ReactiveDictModel {
       duration: [],
       permanent: [],
       states: [],
+      artifacts: [],
       boons: [],
       haven: [],
       gear: [],


### PR DESCRIPTION
Thanks for quick response to my last PR, as promised, here's the new one. 

### Artifacts
The next interesting thing introduced in Renaissance are `Artifacts`. The mechanics here looks similar to `Fool` / `Lost in The Woods` from `Nocturne` so I looked for inspiration in your implementation there. This patch includes three cards from the preview (`Flag Bearer`, `Swashbuckler` and `Treasurer`) among with their corresponding `Artifacts` (`Flag`, `Treasure Chest` & `Key`).

![c4xzj4o](https://user-images.githubusercontent.com/347657/46575890-7c3ad600-c9be-11e8-819f-37676d1ed1ea.png)

I hope I'll find a smart way to implement the last outstanding piece of the preview, `Projects`, soon. Ince again, thanks for everything.

## Update 12.11.2018
Changes:
  - [x] Fixes according to your review
  - [x] `Border Guard` action card with two artifacts:
    - [x] `Horn`
    - [x] `Lantern`
  - [x] Available `Artifacts` are now visible in left column (same place where  `Landmarks` usually are)

![horn](https://user-images.githubusercontent.com/347657/48321441-c731b400-e622-11e8-9c0f-b22f9167fec6.jpg)
![lantern](https://user-images.githubusercontent.com/347657/48321442-c731b400-e622-11e8-9d11-938907f0c0ae.jpg)
![border_guard](https://user-images.githubusercontent.com/347657/48321443-c731b400-e622-11e8-90b1-3d003f5759dc.jpg)
![screen shot 2018-11-12 at 02 29 52](https://user-images.githubusercontent.com/347657/48321455-e16b9200-e622-11e8-9968-b1d10bee43fe.png)
